### PR TITLE
Fix for issue 116 with a failed redirect by Apple authorization URL when scope with value 'name' or 'email' is requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,13 +65,13 @@ const oauthPlugin = fp(function (fastify, options, next) {
 
   function generateAuthorizationUri (requestObject) {
     const state = generateStateFunction(requestObject)
-    const scopeName = Array.isArray(scope) ? scope.join(' ') : scope;
-    const hasResponseMode = scopeName.includes('email') || scopeName.includes('name');
+    const scopeName = Array.isArray(scope) ? scope.join(' ') : scope
+    const hasResponseMode = scopeName.includes('email') || scopeName.includes('name')
     const urlOptions = Object.assign({}, callbackUriParams, {
       redirect_uri: callbackUri,
       scope: scope,
       state: state,
-      ...(hasResponseMode && { response_mode: 'form_post' }),
+      ...(hasResponseMode && { response_mode: 'form_post' })
     })
     const authorizationUri = oauth2.authorizationCode.authorizeURL(urlOptions)
     return authorizationUri

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-oauth2",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "description": "Perform login using oauth2 protocol",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### Description
This fix provides a bugfix for issue #116. No changes for documentation are needed here, because it's implemented and used under the hood regardless of library usage.

![image](https://user-images.githubusercontent.com/9191544/137324787-b3207d2a-36e6-4902-b6ca-60b8042f17d9.png)

All tests are passed:

![image](https://user-images.githubusercontent.com/9191544/137325079-3c4ed7ed-391b-4642-9520-d7c4bf104d26.png)
